### PR TITLE
어플리케이션 게임스크린 수정

### DIFF
--- a/Application/WindowsFormsApp1/Application.csproj
+++ b/Application/WindowsFormsApp1/Application.csproj
@@ -33,8 +33,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DTL, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="DTL">
       <HintPath>..\..\Server\DTL\DTL\bin\Debug\DTL.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Application/WindowsFormsApp1/Client.cs
+++ b/Application/WindowsFormsApp1/Client.cs
@@ -211,7 +211,7 @@ namespace WindowsFormsApp1
         {
             byte[] cbyte = new byte[21];
             byte[] tmp = Encoding.Default.GetBytes(Card_Name);
-            Array.Copy(tmp, 0, cbyte, 0, 21);
+            Array.Copy(tmp, 0, cbyte, 0, tmp.Length);
             Message Amsg = new Message();
             Amsg.Body = new BodyAlertAction()
             {
@@ -230,7 +230,7 @@ namespace WindowsFormsApp1
         {
             byte[] cbyte = new byte[21];
             byte[] tmp = Encoding.Default.GetBytes(Card_Name);
-            Array.Copy(tmp, 0, cbyte, 0, 21);
+            Array.Copy(tmp, 0, cbyte, 0, tmp.Length);
             Message GCmsg = new Message();
             GCmsg.Body = new BodyAlertAction()
             {
@@ -249,7 +249,7 @@ namespace WindowsFormsApp1
         {
             byte[] cbyte = new byte[21];
             byte[] tmp = Encoding.Default.GetBytes(Card_Name);
-            Array.Copy(tmp, 0, cbyte, 0, 21);
+            Array.Copy(tmp, 0, cbyte, 0, tmp.Length);
             Message SCmsg = new Message();
             SCmsg.Body = new BodyAlertAction()
             {

--- a/Application/WindowsFormsApp1/Form2.cs
+++ b/Application/WindowsFormsApp1/Form2.cs
@@ -36,7 +36,7 @@ namespace WindowsFormsApp1
             else
             {
                 Global.UserID = textID.Text;
-                Global.transHandler = new TransHandler("127.0.0.1", 5542, Global.UserID);
+                Global.transHandler = new TransHandler("210.119.12.58", 5542, Global.UserID);
                 /*엘림만 사용*/
 
 

--- a/Application/WindowsFormsApp1/Game.cs
+++ b/Application/WindowsFormsApp1/Game.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace WindowsFormsApp1
 {

--- a/Application/WindowsFormsApp1/Game_Screen.Designer.cs
+++ b/Application/WindowsFormsApp1/Game_Screen.Designer.cs
@@ -732,16 +732,6 @@
             this.label3.TabIndex = 2;
             this.label3.Text = "Treasure : ";
             // 
-            // button1
-            // 
-            this.button1.Location = new System.Drawing.Point(338, 14);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(108, 23);
-            this.button1.TabIndex = 1;
-            this.button1.Text = "AB 종료";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
-            // 
             // label2
             // 
             this.label2.AutoSize = true;

--- a/Application/WindowsFormsApp1/Game_Screen.cs
+++ b/Application/WindowsFormsApp1/Game_Screen.cs
@@ -67,11 +67,11 @@ namespace WindowsFormsApp1
             groupBox10.Text = "My Action / Buy";
             button1.Font = font;
 
-            groupBox1.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\1.png");
-            groupBox3.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\Hand_Background.png");
-            groupBox4.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\Log.png");
-            groupBox5.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\BonoBono.png");
-            groupBox10.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\1.png");
+            //groupBox1.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\1.png");
+            //groupBox3.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\Hand_Background.png");
+            //groupBox4.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\Log.png");
+            //groupBox5.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\BonoBono.png");
+            //groupBox10.BackgroundImage = Image.FromFile(Directory.GetCurrentDirectory() + "\\1.png");
             //pictureBox23.Load(Directory.GetCurrentDirectory() + "\\Diamonds.gif");
            
             label4.Parent = pictureBox123;
@@ -656,11 +656,11 @@ namespace WindowsFormsApp1
             }
             else if (cardaction == "m")
             {
-                make = Global.UserID + "(이)가" + cardname + "카드 구입.";
+                make = Global.UserID + "(이)가 " + cardname + " 카드 구입.";
             }
             else if (cardaction == "h") 
             { 
-                make = Global.UserID + "(이)가" + cardname + "카드로 방어.";
+                make = Global.UserID + "(이)가 " + cardname + " 카드로 방어.";
             }
 
             Log_Handle(make);
@@ -738,7 +738,6 @@ namespace WindowsFormsApp1
 
                             //상대가 먹었음 -> 시장의 카드를 줄임
                             case 3:
-                                setLogBox(Card_Name);
                                 Label[] Ptmp = new Label[CSAmt.Length + marketAmt.Length];
                                 Card[] Ctmp = new Card[market.MarketPile.Count + market.MoneyPile.Count + market.estatePile.Count];
                                 //Label 및 Ctmp 정의
@@ -763,11 +762,15 @@ namespace WindowsFormsApp1
                                 {
                                     Ctmp[Ci++] = C;
                                 }
-
                                 //돌면서 찾고 인덱스 이용해서 숫자감소 및 UI변경
                                 for (int i = 0; i < Ctmp.Length; i++)
                                 {
-                                    if (Ctmp[i].Name.Equals(Card_Name))
+                                    bool strMatch = true;
+                                    for (int j = 0; j < Ctmp[i].Name.Length; j++)
+                                    {
+                                        strMatch = strMatch && (Ctmp[i].Name[j] == Card_Name[j]);
+                                    }
+                                    if (strMatch)
                                     {
                                         Ctmp[i].amount--;
                                         Ptmp[i].Text = Ctmp[i].amount.ToString();

--- a/Server/Dominion_Server/Dominion_Server/Dominion_Server.csproj
+++ b/Server/Dominion_Server/Dominion_Server/Dominion_Server.csproj
@@ -33,8 +33,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DTL, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="DTL">
       <HintPath>..\..\DTL\DTL\bin\Debug\DTL.dll</HintPath>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
병합과정에서 중복되는 코드문제 발생 일단 테스트에 문제되는 부분만 제거하였고 이후 중복되는 코드가 존재하면 수정 필요
카드 이름 비교에서 equals 메소드가 작동되지 않아 다른 방식으로 변경
게임스크린 폼 로드시 이미지 파일이 존재하지 않아 해당 이미지 로드 부분 주석처리